### PR TITLE
fix[PKGBUILD]: fixed build errors + other small bug fixes

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -10,6 +10,7 @@ url="https://github.com/R3alCl0ud/Rust4Diva"
 license=('GPL-3.0')
 depends=('libarchive')
 makedepends=('cargo' 'git')
+conflicts=("${pkgname%-git}" "${pkgname%-git}-bin")
 replaces=('Rust4Diva-git')
 options=(!debug !lto)
 source=("${pkgname%-git}::git+https://github.com/R3alCl0ud/Rust4Diva.git")

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,38 +1,35 @@
-# Maintainer: NeptuneNepgear ultra.neppers@gmail.com
+# Maintainer: NeptuneNepgear <ultra.neppers@gmail.com>
+# Contributor: qwertyuiopleowo <newleowoxl@gmail.com>
 
-pkgname=Rust4Diva-git
-pkgver=r87.7c2d5e5
+pkgname=rust4diva-git
+pkgver=r208.dc5e3d3
 pkgrel=1
 pkgdesc="Project Diva Mod Manager written in rust"
 arch=('x86_64' 'aarch64')
-license=(GPL-3.0)
 url="https://github.com/R3alCl0ud/Rust4Diva"
-makedepends=(
-    cargo
-    git
-)
-depends=( libarchive )
-
-source=('git+https://github.com/R3alCl0ud/Rust4Diva.git')
+license=('GPL-3.0')
+depends=('libarchive')
+makedepends=('cargo' 'git')
+replaces=('Rust4Diva-git')
+options=(!debug !lto)
+source=("${pkgname%-git}::git+https://github.com/R3alCl0ud/Rust4Diva.git")
 sha256sums=('SKIP')
 
 pkgver() {
-    cd "${pkgname%-git}"
-    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+	cd "${pkgname%-git}"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
 }
-
 
 build() {
-    cd "${pkgname%-git}"
-    export RUSTUP_TOOLCHAIN=stable
-    export CARGO_TARGET_DIR=target
-    cargo build --frozen --release --all-features
+	cd "${pkgname%-git}"
+	export RUSTUP_TOOLCHAIN=stable
+	export CARGO_TARGET_DIR=target
+	cargo build --frozen --release --all-features
 }
 
-
 package() {
-    cd "${pkgname%-git}"
-    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/rust4diva"
-    install -Dm0755 -t "$pkgdir/usr/share/icons/" "assets/rust4diva.png"
-    install -Dm0755 -t "$pkgdir/usr/share/applications/" "assets/Rust4Diva.desktop"
+	cd "${pkgname%-git}"
+	install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/rust4diva"
+	install -Dm0755 -t "$pkgdir/usr/share/icons/" "assets/rust4diva.png"
+	install -Dm0755 -t "$pkgdir/usr/share/applications/" "assets/Rust4Diva.desktop"
 }


### PR DESCRIPTION
I noticed the `PKGBUILD` gave errors during the build step, while manually running the `cargo build --frozen --release --all-features` command by itself did no such thing. 

Start of the error messages:
![image](https://github.com/user-attachments/assets/3efc00f9-dc86-43b7-9509-fe5b4d06080b)

End of the error messages:
![image](https://github.com/user-attachments/assets/cbdb3aa2-5e30-43f2-a5b5-53bd7b0de535)

After a bit of digging I've tried revising the `PKGBUILD` to build without errors and adhere to some rules/conventions.

Changes:

- Fixed build function by disabling `debug` and `lto` in `options`. This is the main fix which enables me to build the application without any errors. The error only occurred when using `makepkg` with the previous `PKGBUILD` file. [This issue is known and has been classified as "not a bug"](https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/issues/20#note_172172) 

- Changed package name to all lower case since "Package names should only consist of lowercase alphanumerics and the following characters: @._+- (at symbol, dot, underscore, plus, hyphen)." ([source: arch wiki](https://wiki.archlinux.org/title/PKGBUILD#pkgname))

- Specified unique package name in `source` array. The name is based on the `pkgname`, so `pkgname` matches the name of the source tarball of the software ([source: arch wiki](https://wiki.archlinux.org/title/PKGBUILD#pkgname))

- "Stringified" `license`, `depends`, and `makedepends` array elements/values

- Changed indentation spaces to tabs to follow the [`PKGBUILD-vcs.proto`](https://gitlab.com/arch.linux/pacman/-/blob/master/proto/PKGBUILD-vcs.proto) template in `/usr/share/pacman` and many other `PKGBUILD` files

This is my first pull request so any feedback would be greatly appreciated, though not necessary if you don't have the time